### PR TITLE
Quick README npm module name fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You may install JavaScript SDK with npm by running :
 
 `npm install playfab-web-sdk`
 
-Notice that it will install web JavaScript package as opposed to `npm install playfab` which will install NodeJS SDK.
+Notice that it will install web JavaScript package as opposed to `npm install playfab-sdk` which will install NodeJS SDK.
 
 While npm is generally used for server side packages, you may use one of popular build tools to mix NPM installed packages into your clientside JS codebase. Consider Babel, Webpack, Gulp or Grunt for different approaches to building and automation.
 


### PR DESCRIPTION
I was working on setting up a new project with the Node SDK, and found a slight typo/inaccuracy here — the NPM module for the server-side lib is `playfab-sdk`, not `playfab` (https://www.npmjs.com/package/playfab-sdk). This just fixes that!

Apologies if this repo isn't intended to be human-editable, I couldn't find an obvious spot in https://github.com/PlayFab/SDKGenerator where README files are generated so i assumed this was the right place to open this.

(I'm a MS employee working on Azure developer advocacy — I'm `emwalker` if chatting internally is helpful)